### PR TITLE
Add a .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install:
+  - pip install sphinx
+  - pip install sphinx_rtd_theme
+before_script: mkdir build
+# command to run tests
+script: sphinx-build  -b html . ./build


### PR DESCRIPTION
For now the script just check that the sources build.

The next step will be to change warning into error. But for that the current errors should be corrected:

> mnt/getting_started/eshop_installation.rst:105: WARNING: Definition list ends without a blank line; unexpected unindent.
> /mnt/getting_started/eshop_installation.rst:106: WARNING: Definition list ends without a blank line; unexpected unindent.
> /mnt/themes/index.rst:4: WARNING: toctree contains reference to nonexisting document u'themes/theme_configuration'
> /mnt/themes/index.rst:4: WARNING: toctree contains reference to nonexisting document u'themes/blocks'
