### PR TITLE
Added missing brackets at the composer examples...

### DIFF
--- a/modules/using_namespaces_in_modules.rst
+++ b/modules/using_namespaces_in_modules.rst
@@ -97,11 +97,12 @@ Just create a composer.json in the module's root directory
 ::
 
   {
-    "name": "myvendor/mymodule",
-    "extra": {
-    "oxideshop": {
-      "target-directory": "myvendor/mymodule"
-    }
+      "name": "myvendor/mymodule",
+      "extra": {
+          "oxideshop": {
+              "target-directory": "myvendor/mymodule"
+          }
+      }
   }
 
 
@@ -223,15 +224,17 @@ root directory.
 ::
 
   {
-    "name": "myvendor/mymodule",
-    "autoload": {
-        "psr-4": {
-            "MyVendor\\MyModuleNamespace\\": "./"
-        }
-    "extra": {
-    "oxideshop": {
-      "target-directory": "myvendor/mymodule"
-    }
+      "name": "myvendor/mymodule",
+      "autoload": {
+          "psr-4": {
+              "MyVendor\\MyModuleNamespace\\": "./"
+          }
+      },
+      "extra": {
+          "oxideshop": {
+              "target-directory": "myvendor/mymodule"
+          }
+      }
   }
 
 Then in the shop's root directory do


### PR DESCRIPTION
... and harmonized with four instead of two whitespaces like it is in the paypal module of the eshop version 6 beta 3, too: /source/modules/oe/oepaypal/composer.json (and it is a bit more readable)