### PR TITLE
Fixed changed namespace path 

### DIFF
--- a/development/tell_me_about/event/event_example.rst
+++ b/development/tell_me_about/event/event_example.rst
@@ -58,9 +58,9 @@ a different method for each event. This is completely up to you.
   <?php declare(strict_types=1);
   namespace OxidEsales\Eventexample;
 
-  use OxidEsales\EshopCommunity\Internal\Application\Events\AbstractShopAwareEventSubscriber;
-  use OxidEsales\EshopCommunity\Internal\ShopEvents\AfterModelInsertEvent;
-  use OxidEsales\EshopCommunity\Internal\ShopEvents\AfterModelUpdateEvent;
+  use OxidEsales\EshopCommunity\Internal\Framework\Event\AbstractShopAwareEventSubscriber;
+  use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelInsertEvent;
+  use OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelUpdateEvent;
   use Psr\Log\LoggerInterface;
   use Symfony\Component\EventDispatcher\Event;
 


### PR DESCRIPTION
During copy and paste the code into PHPStorm it said that the namespace path couldn't be resolved. I guess the paths were changed to "Framework\", respectively "Transition\" in the meanwhile.