### PR TITLE
Suggest to use globally one pattern for service keys and namespaces

### DIFF
--- a/development/modules_components_themes/module/module_services.rst
+++ b/development/modules_components_themes/module/module_services.rst
@@ -43,8 +43,8 @@ Then you can register the service in OXID DI Container. Create in root directory
 .. code:: yaml
 
     services:
-        SomeCompany/SpecialERPModule/PriceCalculatorInterface:
-            class: /SomeCompany/SpecialERPModule/ERPPriceCalculator
+        SomeCompany\SpecialERPModule\PriceCalculatorInterface:
+            class: SomeCompany\SpecialERPModule\ERPPriceCalculator
             autowire: true
             public: true
 


### PR DESCRIPTION
Changed the service and namespace names, like it is explained and proposed in the service container docs: https://docs.oxid-esales.com/developer/en/6.2-rc.1/development/modules_components_themes/module/module_services.html or the example from Symfony: https://github.com/symfony/demo/blob/master/config/services.yaml#L33