### PR TITLE
Suggestion to use globally one pattern for service keys

### DIFF
--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -85,7 +85,7 @@ create it in your module root directory.
 .. code:: yaml
 
     services:
-      oxid_esales.demo_module.command.hello_world:
+      OxidEsales\DemoModule\Command\HelloWorld:
         class: OxidEsales\DemoModule\Command\HelloWorldCommand
         tags:
         - { name: 'console.command' }
@@ -101,7 +101,7 @@ In case you need to change command name, it can be done also via `services.yaml`
 .. code:: yaml
 
     services:
-      oxid_esales.demo_component.command.hello_world:
+      OxidEsales\DemoModule\Command\HelloWorld:
         class: OxidEsales\DemoModule\Command\HelloWorldCommand
         tags:
         - { name: 'console.command', command: 'demo-module:say-hello-another-command' }
@@ -163,7 +163,7 @@ create it in your component root directory.
 .. code:: yaml
 
     services:
-      oxid_esales.demo_component.command.hello_world:
+      OxidEsales\DemoComponent\Command\HelloWorld:
         class: OxidEsales\DemoComponent\Command\HelloWorldCommand
         tags:
         - { name: 'console.command' }


### PR DESCRIPTION
Changed the service key to the namespace name, like it is explained and proposed in the service container docs: https://docs.oxid-esales.com/developer/en/6.2-rc.1/development/modules_components_themes/module/module_services.html or the example from Symfony: https://github.com/symfony/demo/blob/master/config/services.yaml#L33