### PR TITLE
file extension .yml resulting in an error

### DIFF
--- a/development/tell_me_about/service_container.rst
+++ b/development/tell_me_about/service_container.rst
@@ -68,7 +68,7 @@ implementation MyProject\CustomLogger, which is specified by the class parameter
 .. note::
 
     There are several possibilities to configure the Symfony DI container.
-    OXID framework only uses and supports the yaml file format.
+    OXID framework only uses and supports the yaml file format. In addition always use file extension .yaml, not .yml.
 
 .. important::
     Please consider the hints in the section :ref:`Stable OXID eShop Core Services <stable_core_services-20191111>`.


### PR DESCRIPTION
The official supported file extensions for YAML files are .yaml and .yml. Unfortunately the OXID eShop only supports file extension .yaml. If you use .yml instead and install your service with composer, the following error occurs:

 [OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Exception\NoServiceYamlException]

I suggest to add this little information to the docs since it's very important.