### PR TITLE
add matomo tracking

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -211,6 +211,9 @@
   {% endif %}
 
   {%- block footer %} {% endblock %}
+  
+  {# Add Matomo tracking - https://analytics.oxid-esales.com #}
+  <script src="{{ pathto('_static/js/matomo.js', 1) }}"></script>
 
 </body>
 </html>

--- a/_themes/sphinx_rtd_theme/static/js/matomo.js
+++ b/_themes/sphinx_rtd_theme/static/js/matomo.js
@@ -1,0 +1,12 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="//analytics.oxid-esales.com/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '8']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();
+


### PR DESCRIPTION
We want to add Matomo tracking additionally, hosted on our own servers at analytics.oxid-esales.com. I intentionally want to check with b-6.2 first if it works at all. If so, I can send PRs for the other branches as well with an ease.