### PR TITLE
Added command to services.yaml due to Bug#7120

### DIFF
--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -88,7 +88,7 @@ create it in your module root directory.
       OxidEsales\DemoModule\Command\HelloWorld:
         class: OxidEsales\DemoModule\Command\HelloWorldCommand
         tags:
-        - { name: 'console.command' }
+        - { name: 'console.command', command: 'demo-module:say-hello' }
 
 Now after module activation, command will be available in commands list and it can be executed via:
 
@@ -166,4 +166,4 @@ create it in your component root directory.
       OxidEsales\DemoComponent\Command\HelloWorld:
         class: OxidEsales\DemoComponent\Command\HelloWorldCommand
         tags:
-        - { name: 'console.command' }
+        - { name: 'console.command', command: 'demo-module:say-hello' }


### PR DESCRIPTION
At the moment it is mandatory to add the command to the services.yaml file. If you don't do that, an error occurs while running Composer which stops the execution of all scripts. This can lead to major issues. See Bugtracker Bug#7120: https://bugs.oxid-esales.com/view.php?id=7120