### PR TITLE
Added version to requiring update-component

### DIFF
--- a/update/update-from-6.1.x-to-6.2.0.rst
+++ b/update/update-from-6.1.x-to-6.2.0.rst
@@ -91,7 +91,7 @@ activation status of your current modules.
 
     .. code:: bash
 
-       composer require --no-interaction oxid-esales/oxideshop-update-component
+       composer require --no-interaction oxid-esales/oxideshop-update-component:"^1.0"
 
 2. Install a default configuration for all modules which are currently inside the directory :file:`source/modules`.
    On the command line, execute the :doc:`console command </development/tell_me_about/console>`:


### PR DESCRIPTION
If you set minimum-stability to "dev" in your composer.json and run

composer require --no-interaction oxid-esales/oxideshop-update-component

the dev-master of the update-component will be installed, which can't handle the update process (at the moment). You must use a stable version. For this reason, require the package with a version constraint:

composer require --no-interaction oxid-esales/oxideshop-update-component:"^1.0"

This results in a stable installation and therefore a successfull update.