### PR TITLE
Changed module dir to modules root dir

### DIFF
--- a/development/modules_components_themes/module/skeleton/metadataphp/index.rst
+++ b/development/modules_components_themes/module/skeleton/metadataphp/index.rst
@@ -3,7 +3,7 @@ metadata.php
 
 Since OXID eShop version 4.9.0 / 5.2.0
 (`Release notes <https://docs.oxid-esales.com/eshop/de/5.3/releases/releases-2014/oxid-eshop-490520.html>`__)
-each module has to have metadata set. This has to be done with a file :file:`metadata.php` in the module directory.
+each module has to have metadata set. This has to be done with a file :file:`metadata.php` in the modules root directory.
 
 .. note::
 


### PR DESCRIPTION
Some developers tried to put the metadata.php file into a subdirectory, which should be ok with the current documentation. However, it is not intended do so and will lead to an error at the deinstallation of a module. Therefore it has to be made clear.