### PR TITLE
admin translations possible in more directories

### DIFF
--- a/development/modules_components_themes/module/skeleton/structure.rst
+++ b/development/modules_components_themes/module/skeleton/structure.rst
@@ -117,6 +117,8 @@ Admin
 Translation files can be placed in
 
 * ``Application/views/admin/``
+* ``application/views/admin/``
+* ``views/admin/``
 
 Example:
 


### PR DESCRIPTION
Nowadays it is not always common to use the *Application/* directory in a module anymore. You can see this in OXID's own PayPal module. Like the frontend translations, the *Application/* directory must not be available for the translation files for the administration area. I've tested this with the *module_options.php* files and it worked fine and as said before it is also the case in the oepaypal module.

Therefore, as also described in the frontend translations section, it is possible to have a fully lowercase *application/* directory. I tested this also for the *module_options.php* files and it works fine, too.