### PR TITLE
fixed namespaces of events

### DIFF
--- a/development/tell_me_about/event/DIContainerEvents/ProjectYamlChangedEvent.rst
+++ b/development/tell_me_about/event/DIContainerEvents/ProjectYamlChangedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-	Namespace: OxidEsales\EshopCommunity\Internal\Application\Events\ProjectYamlChangedEvent
+	OxidEsales\EshopCommunity\Internal\Framework\DIContainer\Event\ProjectYamlChangedEvent;
 
 This event will be dispatched after the generated services file for the DI container has changed.
 This happens when a module that has its own `services.yaml` file is activated, for example.

--- a/development/tell_me_about/event/DIContainerEvents/ServicesYamlConfigurationErrorEvent.rst
+++ b/development/tell_me_about/event/DIContainerEvents/ServicesYamlConfigurationErrorEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-	Namespace: OxidEsales\EshopCommunity\Internal\Module\Setup\Event\ServicesYamlConfigurationErrorEvent
+	OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event\ServicesYamlConfigurationErrorEvent;
 
 This event will be dispatched when there are classes referenced in a `services.yaml` file of a module
 that are not loadable.

--- a/development/tell_me_about/event/DatabaseEvents/AfterModelDeleteEvent.rst
+++ b/development/tell_me_about/event/DatabaseEvents/AfterModelDeleteEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\AfterModelDeleteEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelDeleteEvent
 
 This event will be dispatched after the model data is deleted from database.
 

--- a/development/tell_me_about/event/DatabaseEvents/AfterModelInsertEvent.rst
+++ b/development/tell_me_about/event/DatabaseEvents/AfterModelInsertEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\AfterModelInsertEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelInsertEvent
 
 This event will be dispatched after the model data is inserted to database.
 

--- a/development/tell_me_about/event/DatabaseEvents/AfterModelUpdateEvent.rst
+++ b/development/tell_me_about/event/DatabaseEvents/AfterModelUpdateEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\AfterModelUpdateEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterModelUpdateEvent
 
 This event will be dispatched after the model data is updated in database.
 

--- a/development/tell_me_about/event/DatabaseEvents/BeforeModelDeleteEvent.rst
+++ b/development/tell_me_about/event/DatabaseEvents/BeforeModelDeleteEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\BeforeModelDeleteEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeModelDeleteEvent
 
 This event will be dispatched before model is deleted from database.
 

--- a/development/tell_me_about/event/DatabaseEvents/BeforeModelUpdateEvent.rst
+++ b/development/tell_me_about/event/DatabaseEvents/BeforeModelUpdateEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\BeforeModelUpdateEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeModelUpdateEvent
 
 This event will be dispatched before model state is changed in database.
 

--- a/development/tell_me_about/event/ModuleEvents/BeforeModuleDeactivationEvent.rst
+++ b/development/tell_me_about/event/ModuleEvents/BeforeModuleDeactivationEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\Module\Setup\Event\BeforeModuleDeactivationEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event\BeforeModuleDeactivationEvent
 
 This event will be dispatched right before the module deactivation for a specific shop.
 

--- a/development/tell_me_about/event/ModuleEvents/FinalizingModuleActivationEvent.rst
+++ b/development/tell_me_about/event/ModuleEvents/FinalizingModuleActivationEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\Module\Setup\Event\FinalizingModuleActivationEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event\FinalizingModuleActivationEvent
 
 This event will be dispatched at the last step of the module activation for a specific shop.
 

--- a/development/tell_me_about/event/ModuleEvents/FinalizingModuleDeactivationEvent.rst
+++ b/development/tell_me_about/event/ModuleEvents/FinalizingModuleDeactivationEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    OxidEsales\EshopCommunity\Internal\Module\Setup\Event\FinalizingModuleDeactivationEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Event\FinalizingModuleDeactivationEvent
 
 This event will be dispatched at the last step of the module deactivation for a specific shop.
 

--- a/development/tell_me_about/event/ModuleEvents/SettingChangedEvent.rst
+++ b/development/tell_me_about/event/ModuleEvents/SettingChangedEvent.rst
@@ -1,9 +1,11 @@
 SettingChangedEvent
 ===================
 
+Namespace:
+
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\Module\Setting\Event\SettingChangedEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Module\Setting\Event\SettingChangedEvent
 
 This event will be triggered when shop module settings have been changed in database.
 

--- a/development/tell_me_about/event/ModuleEvents/ShopConfigurationChangedEvent.rst
+++ b/development/tell_me_about/event/ModuleEvents/ShopConfigurationChangedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\Adapter\Configuration\Event\ShopConfigurationChangedEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Config\Event\ShopConfigurationChangedEvent
 
 This event will be triggered when shop configuration was changed in database.
 

--- a/development/tell_me_about/event/ShopGeneralEvents/AfterRequestProcessedEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/AfterRequestProcessedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\AfterRequestProcessedEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AfterRequestProcessedEvent
 
 This event will be dispatched by shop to inform services that a request has been processed.
 

--- a/development/tell_me_about/event/ShopGeneralEvents/AllCookiesRemovedEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/AllCookiesRemovedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\AllCookiesRemovedEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\AllCookiesRemovedEvent
 
 This event will be dispatched after the shop called the cookie removal method. For example in case of cookie note decline,
 shop has to remove all cookies.

--- a/development/tell_me_about/event/ShopGeneralEvents/ApplicationExitEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/ApplicationExitEvent.rst
@@ -9,13 +9,15 @@ Namespace:
 
 This event will be dispatched when the shop is preparing for emergency exit.
 
-NOTE: modules should only register headers in
+.. Note::
 
-.. code-block:: php
+    modules should only register headers in
+  
+        .. code-block:: php
 
-    \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Header::class);
+            \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Header::class);
 
-but leave actual sending of headers to shop.
+    but leave actual sending of headers to shop.
 
 Usage example: reverse proxy (varnish) can use this event to ensure all headers and cookies needed by the module
 are in place for the next request.

--- a/development/tell_me_about/event/ShopGeneralEvents/ApplicationExitEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/ApplicationExitEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\ApplicationExitEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\ApplicationExitEvent
 
 This event will be dispatched when the shop is preparing for emergency exit.
 

--- a/development/tell_me_about/event/ShopGeneralEvents/BasketChangedEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/BasketChangedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\BasketChangedEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BasketChangedEvent
 
 This event will be dispatched when the basket was changed.
 

--- a/development/tell_me_about/event/ShopGeneralEvents/BeforeHeadersSendEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/BeforeHeadersSendEvent.rst
@@ -10,13 +10,14 @@ Namespace:
 This event will be dispatched before the shop sends the headers.
 
 .. Note::
- modules should only register headers in
 
-.. code-block:: php
+    modules should only register headers in
+  
+        .. code-block:: php
 
-    \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Header::class);
+            \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\Header::class);
 
-but leave actual sending of headers to shop.
+    but leave actual sending of headers to shop.
 
 Usage example: reverse proxy (varnish) uses this event to set its cookies and decide if
 reverse proxy functionality should be used for this response or not.

--- a/development/tell_me_about/event/ShopGeneralEvents/BeforeHeadersSendEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/BeforeHeadersSendEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\BeforeHeadersSendEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeHeadersSendEvent
 
 This event will be dispatched before the shop sends the headers.
 

--- a/development/tell_me_about/event/ShopGeneralEvents/BeforeSessionStartEvent.rst
+++ b/development/tell_me_about/event/ShopGeneralEvents/BeforeSessionStartEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\BeforeSessionStartEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\BeforeSessionStartEvent
 
 This event will be dispatched by shop to inform services that session is about to be started.
 

--- a/development/tell_me_about/event/ViewEvents/ThemeSettingChangedEvent.rst
+++ b/development/tell_me_about/event/ViewEvents/ThemeSettingChangedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\Theme\Event\ThemeSettingChangedEvent
+    OxidEsales\EshopCommunity\Internal\Framework\Theme\Event\ThemeSettingChangedEvent
 
 This event will be triggered when theme settings have been changed in database.
 

--- a/development/tell_me_about/event/ViewEvents/ViewRenderedEvent.rst
+++ b/development/tell_me_about/event/ViewEvents/ViewRenderedEvent.rst
@@ -5,7 +5,7 @@ Namespace:
 
 .. code-block:: php
 
-    Namespace: OxidEsales\EshopCommunity\Internal\ShopEvents\ViewRenderedEvent
+    OxidEsales\EshopCommunity\Internal\Transition\ShopEvents\ViewRenderedEvent
 
 This event will be dispatched after the shop has rendered the current
 page for output. Before this event is sent, all processing of the current request


### PR DESCRIPTION
Namespaces of all events were wrong.
The label "Namespace:" should not be in the code box. It is mentioned directly above.
Also fixed two note boxes.