### PR TITLE
added mention of EE only

### DIFF
--- a/development/modules_components_themes/project/module_configuration/modules_configuration_deployment.rst
+++ b/development/modules_components_themes/project/module_configuration/modules_configuration_deployment.rst
@@ -151,7 +151,7 @@ To apply configuration use the following command:
 
     vendor/bin/oe-console oe:module:apply-configuration
 
-Provide ``--shop-id`` option if it is only for one shop.
+Provide ``--shop-id`` option if you are using an OXID eShop Enterprise Edition and it is only for one shop.
 
 .. code:: bash
 


### PR DESCRIPTION
The *--shop-id* parameter is only intended to be used with EE. Currently it will trigger an error if used wit CE/PE. Therefore it should be made clear in the docs to use it only if you are using an EE.