### PR TITLE
fixed broken formating after update

### DIFF
--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -86,9 +86,9 @@ create it in your module root directory.
 
     Do not add a leading backslash to the classname.
     
-    wrong: `class: \OxidEsales\DemoModule\Command\HelloWorldCommand`
+    wrong: `class: \\OxidEsales\\DemoModule\\Command\\HelloWorldCommand`
     
-    correct: `class: OxidEsales\DemoModule\Command\HelloWorldCommand`
+    correct: `class: OxidEsales\\DemoModule\\Command\\HelloWorldCommand`
 
 .. code:: yaml
 
@@ -101,7 +101,7 @@ create it in your module root directory.
 .. important::
 
     Despite specifying `command: 'demo-module:say-hello'` explicitly is not needed, we highly recommend to do so,
-    because you will likely run into [this issue](https://stackoverflow.com/a/61655652/2123108) otherwise.
+    because you will likely run into `this issue <https://stackoverflow.com/a/61655652/2123108>`__ otherwise.
 
 Now after module activation, command will be available in commands list and it can be executed via:
 


### PR DESCRIPTION
Looks broke to me: 
![image](https://user-images.githubusercontent.com/1001186/96454342-fe9c3880-121b-11eb-92db-8f4879fd3b47.png)

Sorry about that, I hope this will fix it. I wanted to do that locally, but I failed to install the sphinx extensions on my local machine.
