### PR TITLE
Added a info box with a "is from version available" text

### DIFF
--- a/development/modules_components_themes/module/uninstall/index.rst
+++ b/development/modules_components_themes/module/uninstall/index.rst
@@ -23,3 +23,8 @@ In order to remove module configurations from shop configuration, following comm
     vendor/bin/oe-console oe:module:uninstall-configuration <module-id>
 
 
+.. note::
+
+    This command is available from version `6.2.3 <https://oxidforge.org/en/oxid-eshop-version-6-2-3.html>`_.
+    
+     


### PR DESCRIPTION
This feature was introduced with 6.2.3, but the documentation is generally for version 6.2. So a note box which states that this command is only available since version 6.2.3 should clarify the situation.
I linked to the oxidforge release notes as this page is also written in english.