### PR TITLE
Fixed format for help texts

### DIFF
--- a/development/modules_components_themes/module/skeleton/metadataphp/amodule/settings.rst
+++ b/development/modules_components_themes/module/skeleton/metadataphp/amodule/settings.rst
@@ -37,7 +37,7 @@ Usage
     
     Add **translations of your module's settings** into each copy of corresponding :file:`module_options.php` file
     (see :ref:`File and Folder structure <modules_structure_language_files_admin>`)
-    using the following format for language constants ``SHOP_MODULE_GROUP_``, ``SHOP_MODULE_`` and ``HELP_MODULE``.
+    using the following format for language constants ``SHOP_MODULE_GROUP_``, ``SHOP_MODULE_`` and ``HELP_SHOP_MODULE_``.
 
     .. code:: php
 


### PR DESCRIPTION
Language constants for help texts must start with HELP_SHOP_MODULE_ instead of HELP_MODULE. The example shows it the correct way.