### PR TITLE
Added 6.5 compatibility

### DIFF
--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -67,6 +67,8 @@ First of all it's necessary to create a command class. Command class example:
         protected function execute(InputInterface $input, OutputInterface $output)
         {
             $output->writeln('Hello world!');
+            
+            return 0;
         }
     }
 
@@ -160,6 +162,8 @@ Component command example:
         protected function execute(InputInterface $input, OutputInterface $output)
         {
             $output->writeln('Hello World!');
+            
+            return 0;
         }
     }
 


### PR DESCRIPTION
Since OXID eShop 6.5: While the old commands will still be executed, you get an error in `oxideshop.log` regardless:
```
Return value of "Foo\Bar::execute()" must be of the type int, "null" returned.
```

Therefore you should return any integer to remove the error. The commands coming with the shop simply return 0.