### PR TITLE
Use the fully qualified class name instead of the old identifier.

### DIFF
--- a/development/modules_components_themes/module/certification/inter_module_compatibility.rst
+++ b/development/modules_components_themes/module/certification/inter_module_compatibility.rst
@@ -76,5 +76,5 @@ For creating objects, always use the oxNew() function in order to have the modul
 
 .. code:: php
 
-    $Article = oxNew('Article');
+    $article = oxNew(\OxidEsales\Eshop\Application\Model\Article::class);
 


### PR DESCRIPTION
see https://docs.oxid-esales.com/developer/en/6.2/development/modules_components_themes/module/using_namespaces_in_modules.html?highlight=article#the-unified-namespace-oxidesales-eshop