### PR TITLE
Removed component repos.

### DIFF
--- a/update/eshop_from_65_to_7/install_smarty_engine.rst
+++ b/update/eshop_from_65_to_7/install_smarty_engine.rst
@@ -94,12 +94,6 @@ Remove Twig and add Smarty components.
 
    .. code:: shell
 
-      composer config repositories.oxid-esales/smarty-component-pe \
-                --json '{"type":"git", "url":"https://github.com/OXID-eSales/smarty-component-pe.git"}'
-
-      composer config repositories.oxid-esales/smarty-component-ee \
-                --json '{"type":"git", "url":"https://github.com/OXID-eSales/smarty-component-ee.git"}'
-
       composer require --no-update oxid-esales/smarty-component v1.0.0
       composer require --no-update oxid-esales/smarty-component-pe v1.0.0
       composer require --no-update oxid-esales/smarty-component-ee v1.0.0


### PR DESCRIPTION
The GitHub repos must not be added, since they are private and therefore not accessible anyway. The repos where moved to the PE and EE Satis packages and can be installed without any further configuration.