### PR TITLE
Removed command name in services.yaml

### DIFF
--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -94,12 +94,7 @@ create it in your module root directory.
       OxidEsales\DemoModule\Command\HelloWorld:
         class: OxidEsales\DemoModule\Command\HelloWorldCommand
         tags:
-        - { name: 'console.command', command: 'demo-module:say-hello' }
-
-.. important::
-
-    Despite specifying `command: 'demo-module:say-hello'` explicitly is not needed, we highly recommend to do so,
-    because you will likely run into `this issue <https://stackoverflow.com/a/61655652/2123108>`__ otherwise.
+        - { name: 'console.command' }
 
 Now after module activation, command will be available in commands list and it can be executed via:
 
@@ -179,7 +174,7 @@ create it in your component root directory.
       OxidEsales\DemoComponent\Command\HelloWorld:
         class: OxidEsales\DemoComponent\Command\HelloWorldCommand
         tags:
-        - { name: 'console.command', command: 'demo-module:say-hello' }
+        - { name: 'console.command' }
 
 Command testing
 ---------------


### PR DESCRIPTION
While omitting the command name in the services.yaml file could lead to errors in older shop versions, it's not an issue anymore. We omit this part for quite some time in Academy trainings and had never problems. This goes back some version 6 iteration but to make it easy, I suggest to don't change any v6 documentation. Nevertheless we should omit it starting with OXID eShop 7.0 documentation.

The issue was due to an older symfony/console version (<3.4) used by Composer that missed a method. However, current shop 7.0 uses symfony/console 6.2 and composer 2.4 which supports "^5.4.11 || ^6.0.11". Therefore definitely not a problem anymore.