### PR TITLE
b-7.0: Overhauled uninstall module page

### DIFF
--- a/development/modules_components_themes/module/uninstall/index.rst
+++ b/development/modules_components_themes/module/uninstall/index.rst
@@ -1,28 +1,33 @@
 Uninstall
 =========
 
-Uninstall module completely
----------------------------
-
-You can easily uninstall module using composer and
-`OXID eShop Composer Plugin <https://github.com/OXID-eSales/oxideshop_composer_plugin>`__ will do the following steps before composer uninstalling module:
-
-* Deactivate the module if it is already active.
-* Remove module configurations from shop configuration file and remove module classes from module chain.
-   .. todo: #HR: what does the following todo mean?
-   .. todo: (see below)
-
-* Remove module source files
-
-Then, composer will remove module from autoloader and rebuild the autoloader.
-
-Uninstall module without composer
+Uninstall module
 ---------------------------------
 
-To just uninstall the module without removing it via composer, use the following command:
+To uninstall a module without removing the files from the vendor directory, use the following command:
 
 .. code:: bash
 
-    vendor/bin/oe-console oe:module:uninstall <module-id>
+    ./vendor/bin/oe-console oe:module:uninstall <module-id>
 
-Unless a module is removed via composer, it still can be installed again via console.
+Unless a module is removed via Composer, it can be installed via :doc:`oe-console </development/tell_me_about/console>` again.
+
+Remove module
+---------------------------
+
+.. code:: bash
+
+    composer remove vendor/package
+
+By executing the Composer command to remove a package, the
+`OXID eShop Composer Plugin <https://github.com/OXID-eSales/oxideshop_composer_plugin>`__ does a couple of steps to
+remove module information, if the package is of type :ref:`oxideshop-module <module_type-20160524>`:
+
+* Deactivate the module if it is active.
+* Remove module configurations from shop configuration files.
+* Remove module classes from module chain.
+* Clear the cache.
+* Rebuild the :ref:`Service Container <service_container_01>`.
+
+After that, Composer will remove the module from the vendor directory and its autoloader.
+


### PR DESCRIPTION
- moved uninstall to the top and removing it to the bottom
- crosslinked other important topics (oe-console, DI container, ...)
- updated list of action of the composer plugin