### PR TITLE
Add notice box deactivate modules

### DIFF
--- a/development/modules_components_themes/component.rst
+++ b/development/modules_components_themes/component.rst
@@ -4,22 +4,26 @@ OXID eShop Component
 .. note::
     Watch a short video tutorial on YouTube: `Components & Services <https://www.youtube.com/watch?v=tgopDKPiUZE>`_.
 
-OXID eShop component is a simple way for a project to add reusable code to the application via composer packages.
+OXID eShop component is a simple way for a project to add reusable code to the application via Composer packages.
 You can write classes that have new or extended functionality and you may wire these classes together in your
-composer package :doc:`by using the Service Container </development/tell_me_about/service_container>`.
+Composer package by using the :doc:`Service Container </development/tell_me_about/service_container>`.
 
-In contrast to modules, components do not need to be activated but just installed by composer.
+In contrast to modules, components do not need to be activated but just installed by Composer.
 
 How it works
 ------------
 
-On installation the OXID composer plugin will include your components :file:`services.yaml` file in a file
+.. _component-how-it-works:
+
+On installation the OXID Composer plugin will include your components :file:`services.yaml` file in a file
 named :file:`generated_services.yaml` that is read when the DI container is assembled.
 You will find this file in :file:`var/generated` but you should not alter it manually.
 
 
 Component type
 --------------
+
+.. _component-type:
 
 It's necessary that component would have `oxideshop-component` type in `composer.json` file:
 
@@ -28,3 +32,30 @@ It's necessary that component would have `oxideshop-component` type in `composer
     {
         "type": "oxideshop-component",
     }
+
+
+Installation
+--------------
+
+.. _component-installation:
+
+When requiring a package with Composer the `OXID eShop Composer Plugin <https://github.com/OXID-eSales/oxideshop_composer_plugin>`__
+checks the package type. If the type is `oxideshop-component` then the package is installed as an OXID eShop component.
+
+.. code:: bash
+
+    composer require vendor/package
+
+During the installation the `services.yaml` file is imported into the :ref:`Service Container <service_container_01>`.
+After that, the component is globally and permanent active.
+
+Uninstallation
+--------------
+
+.. _component-uninstallation:
+
+To uninstall the OXID eShop component, it's necessary to execute Composer's remove command:
+
+.. code:: bash
+
+    composer remove vendor/package

--- a/development/modules_components_themes/component.rst
+++ b/development/modules_components_themes/component.rst
@@ -54,7 +54,7 @@ Uninstallation
 
 .. _component-uninstallation:
 
-To uninstall the OXID eShop component, it's necessary to execute Composer's remove command:
+To uninstall a OXID eShop component, it's necessary to execute Composer's remove command:
 
 .. code:: bash
 

--- a/development/modules_components_themes/module/deactivation/index.rst
+++ b/development/modules_components_themes/module/deactivation/index.rst
@@ -1,0 +1,24 @@
+Deactivation
+============
+
+by console
+----------
+
+.. _modules_deactivation_console_20240806:
+
+To deactivate a module via :doc:`oe-console </development/tell_me_about/console>`, execute the following command:
+
+.. code:: bash
+
+    ./vendor/bin/oe-console oe:module:deactivate <module-id>
+
+.. note::
+    The parameter :code:`--shop-id` must be appended, if the module must be deactivated for a certain sub shop.
+
+by administration area
+----------------------
+
+.. _modules_deactivation_administration_area_20240806:
+
+1. Open OXID eShop administration panel and go to :menuselection:`Extensions --> Modules`.
+2. Choose the module and click the :guilabel:`Deactivate` button.

--- a/development/modules_components_themes/module/index.rst
+++ b/development/modules_components_themes/module/index.rst
@@ -17,9 +17,11 @@ The following sections all refer to implementing, understanding or using modules
     :glob:
 
     installation_setup/index
-    uninstall/index
     skeleton/index
     *
     database_migration/index
     certification/index
     tutorials/index
+    deactivation/index
+    uninstall/index
+

--- a/development/modules_components_themes/module/installation_setup/setup.rst
+++ b/development/modules_components_themes/module/installation_setup/setup.rst
@@ -26,19 +26,7 @@ To activate a module for a sub shop, use the following option:
 
 .. code:: bash
 
-    vendor/bin/oe-console oe:module:activate <module-id> --shop-id <shop-id>
-
-To deactivate a module, execute the following command:
-
-.. code:: bash
-
-    vendor/bin/oe-console oe:module:deactivate <module-id>
-
-Deactivation for a sub shop:
-
-.. code:: bash
-
-    vendor/bin/oe-console oe:module:deactivate <module-id> --shop-id <shop-id>
+    vendor/bin/oe-console oe:module:activate <module-id> --shop-id=<shop-id>
 
 .. note::
 

--- a/development/modules_components_themes/module/uninstall/index.rst
+++ b/development/modules_components_themes/module/uninstall/index.rst
@@ -1,8 +1,11 @@
-Uninstall
-=========
+Uninstallation
+==============
 
 Uninstall module
----------------------------------
+----------------
+
+.. _modules_uninstall_uninstall_20240806:
+
 
 To uninstall a module, use the following command:
 
@@ -16,7 +19,9 @@ To uninstall a module, use the following command:
 Unless a module is removed via Composer, it can be installed via :doc:`oe-console </development/tell_me_about/console>` again.
 
 Remove module
----------------------------
+--------------
+
+.. _modules_uninstall_remove_20240806:
 
 .. code:: bash
 

--- a/development/tell_me_about/console.rst
+++ b/development/tell_me_about/console.rst
@@ -23,6 +23,8 @@ In case you are using Enterprise Edition subshops feature, to get list of specif
 
     If <shop-id> will not be defined: shop 1, going to be used.
 
+.. _cli-commands-example:
+
 Some other commands examples:
 
 .. code:: bash

--- a/update/eshop_from_65_to_7/update-to-7.1.rst
+++ b/update/eshop_from_65_to_7/update-to-7.1.rst
@@ -22,17 +22,23 @@ Before you update to OXID eShop version 7.1, you have make sure that you meet th
 |procedure|
 
 .. important::
-   **Data loss**
+   **Avoid data loss**
 
-   Avoid data loss.
+   * Make a backup of the database.
+   * Make a backup of the shop files.
 
-   Make a backup of your database. Make a backup of your current shop installation (all files etc.).
+   We strongly recommend to test the update procedure on a copy/development installation of your shop first, to become familiar with the process.
 
-   We recommend to test the update procedure on a copy/development installation of your shop first, to become familiar with the process.
+.. important::
+   **Disable modules and components**
 
+   * :doc:`Deactivate all modules </development/modules_components_themes/module/deactivation/index>`.
+   * :ref:`Uninstall all custom components <component-uninstallation>`.
+
+   Modules and Components can have impact on the framework functionality, which could break the update process. Also they might not be compatible with the updated shop framework and cause issues.
 .. note::
 
-   To execute commands via the command line, open a shell in the shop root directory and run commands in there.
+ To execute commands via the command line, open a shell in the shop root directory and run commands in there.
 
 1. In the :file:`var/configuration` folder, make a backup of the :file:`shops` folder that contains a :file:`<shop-id>.yaml` file for each subshop.
    |br|


### PR DESCRIPTION
This pull request is basically just about one note box in the update documentation, to disable modules and components before starting the update process.

<img width="743" alt="Screenshot 2024-08-06 at 16 30 48" src="https://github.com/user-attachments/assets/bead1c81-979a-4716-afe1-0836c32cafee">

-------

During that, the page modules/deactivation was created and the deactivation part was removed from the setup page:
<img width="757" alt="Screenshot 2024-08-06 at 16 31 28" src="https://github.com/user-attachments/assets/413a562b-fe8c-42b9-afff-861533bda42a">
<img width="755" alt="Screenshot 2024-08-06 at 16 31 20" src="https://github.com/user-attachments/assets/98312475-1096-46d9-b20f-5d3fa8d58e01">

-------

The page components/index was enhanced by the sections installation and uninstallation sections.
<img width="623" alt="Screenshot 2024-08-06 at 16 33 41" src="https://github.com/user-attachments/assets/807a1b5e-411a-4148-8bc3-2b8ebaa95410">

-------

The navigation was changed by moving modules/uninstall (now uninstallation) to the bottom and the item deactivation was added.
<img width="307" alt="Screenshot 2024-08-06 at 16 29 01" src="https://github.com/user-attachments/assets/0b5b38a4-4d6f-4a28-ba5e-3ea15baec85c">

-------

And a couple of anchor points were created.
