### PR TITLE
use dot slash to enforce execution from current context

### DIFF
--- a/update/standard-update.rst
+++ b/update/standard-update.rst
@@ -70,7 +70,7 @@ need to confirm that the update will overwrite the existing files.
 
 .. code:: bash
 
-   vendor/bin/oe-eshop-db_migrate migrations:migrate
+   ./vendor/bin/oe-eshop-db_migrate migrations:migrate
 
 |schritt| Optional: Generating views
 ------------------------------------
@@ -79,7 +79,7 @@ generated again.
 
 .. code:: bash
 
-   vendor/bin/oe-eshop-db_views_generate
+   ./vendor/bin/oe-eshop-db_views_generate
 
 .. hint::
 


### PR DESCRIPTION
Same applies to b-7.2.

Background information:

> What is dot slash?
> In computing, "dot slash" refers to the "./" notation used in Unix-like operating systems to execute a script or a program that's in the current directory. The dot represents the current directory itself, and the slash is a directory separator. So, when you type "./" before a script name, you're telling the system to look for the script right here in the current folder, not anywhere in the system's path.
> 
> Does the dot slash only work on Unix or Linux®?
> Yes, the dot slash convention is specific to Unix-like systems, which include Linux®, and other Unix derivatives. These systems use it to differentiate between executables in the current directory and executables located in the system path. It's not used in Windows, where you can run executables in the current directory without it.

Source: https://www.lenovo.com/us/en/glossary/dot-slash/?orgRef=https%253A%252F%252Fwww.google.com%252F