### PR TITLE
Update modules.rst

### DIFF
--- a/update/eshop_from_65_to_7/modules/modules.rst
+++ b/update/eshop_from_65_to_7/modules/modules.rst
@@ -94,7 +94,7 @@ Adjust removed functionality
        .. code:: bash
 
             composer require rector/rector --dev
-            composer require oxid-esales/oxideshop-update-component --dev
+            composer require oxid-esales/oxideshop-update-component:dev-b-7.0.x --dev
 
 
 


### PR DESCRIPTION
Provide the right version of `oxid-esales/oxideshop-update-component` to install. Without this information more developers will lose theirs time and theirs hairs (for those who still have some)